### PR TITLE
fix(metadata): point documentation at this crate's own docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A correctness-first Rust implementation of fixed-grid Kolmogorov-
 license = "MIT"
 repository = "https://github.com/AndresCdo/kan-rust"
 homepage = "https://github.com/AndresCdo/kan-rust"
-documentation = "https://docs.rs/kan"
+documentation = "https://github.com/AndresCdo/kan-rust/blob/main/docs/TECHNICAL.md"
 keywords = ["kan", "machine-learning", "splines", "neural-network"]
 categories = ["algorithms", "science"]
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ For `G` grid intervals on `[a, b]`, the core uses degree `p = 3`, `G + 3`
 coefficients, and `G + 7` exterior-extended uniform knots. The paper and
 pykan call `p` an "order"; this crate uses the conventional term **degree**.
 
+[docs/TECHNICAL.md](docs/TECHNICAL.md) is the core contract: implemented
+versus deferred scope, the knot and gradient conventions, and the validation
+rules the loader and trainer enforce.
+
 ## Installation
 
 Build this checkout:


### PR DESCRIPTION
## Problem

`Cargo.toml` declared:

```toml
documentation = "https://docs.rs/kan"
```

That URL does not host this crate. The `kan` name on crates.io is taken by an
unrelated project — [`kan-tools/kan`](https://github.com/kan-tools/kan),
described as *"Local reasoning, global coherence — memory for AI agents"*,
currently v0.12.0-beta.3. Anyone following the manifest link, or the
`Documentation` link crates.io would render, landed on a stranger's API docs.

## Why not just drop the field

Per the [Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field),
omitting `documentation` makes crates.io auto-link the matching docs.rs page.
That fallback does not help here: this crate is not published to crates.io
(`kan-rust` returns 404 there), and it cannot claim the `kan` name, which is
already taken. Omitting the field would remove the wrong link without
providing a right one.

## Change

- `documentation` now points at `docs/TECHNICAL.md`, the crate's real
  documentation, already present on `main`.
- The README links that document. It was previously unreachable from the front
  page — no file in the repository referenced it.

Naming is left alone: renaming the package is a breaking change and out of
scope for a metadata fix. It is worth deciding separately, since the current
name cannot be published as-is.

## Verification

All four checks the CI workflow runs, executed locally on this branch:

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --locked --all-targets -- -D warnings` | exit 0, no warnings |
| `cargo test --locked --all-targets` | 24 passed, 0 failed |
| `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps` | exit 0 |

Additionally:

- `cargo metadata --no-deps` reports the new URL, confirming Cargo parses it
  rather than just the text changing.
- The target page resolves and renders "KAN Core Technical Contract".
- `grep -rn "docs\.rs"` over the tree now returns zero matches; `Cargo.toml:10`
  was the only occurrence in the repository.

